### PR TITLE
require crystal >= 0.35.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -2,5 +2,5 @@ name: cr_zip_tricks
 version: 0.2.0
 authors: ["Julik Tarkhanov <me@julik.nl>"]
 description: "An alternate ZIP writer for Crystal, ported from zip_tricks for Ruby"
-crystal: 0.35.1
+crystal: ">= 0.35.1"
 license: MIT


### PR DESCRIPTION
Fixes `shards install` with Crystal 1.0.0

```
shards install             
Resolving dependencies
Fetching https://github.com/wetransfer/cr_zip_tricks.git
Unable to satisfy the following requirements:

- `crystal (~> 0.35, >= 0.35.1)` required by `cr_zip_tricks 0.2.0+git.commit.2efcb646558bdbac411732704d834e5a3d6012a1`
Failed to resolve dependencies, try updating incompatible shards or use --ignore-crystal-version as a workaround if no update is available.
```